### PR TITLE
Fix for issue #459

### DIFF
--- a/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
+++ b/core/src/main/java/com/pierfrancescosoffritti/androidyoutubeplayer/core/player/views/LegacyYouTubePlayerView.kt
@@ -195,6 +195,10 @@ internal class LegacyYouTubePlayerView(context: Context, attrs: AttributeSet? = 
         youTubePlayer.pause()
         playbackResumer.onLifecycleStop()
         canPlay = false
+        try {
+            context.unregisterReceiver(networkListener)
+        } catch (ignore: Exception) {
+        }
     }
 
     /**


### PR DESCRIPTION
When onStop is called, LegacyYoutubePlayer doesn't unregister the networkListener and this seems to cause a memory leak. I added the same code as in line 181 of LegacyYoutubePlayer which seems to do the trick.